### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Fillout.io MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@danielma-tic/server-fillout)](https://smithery.ai/server/@danielma-tic/server-fillout)
+
 MCP Server for the Fillout.io API, enabling form management, response handling, and analytics.
 
 ## Token Setup
@@ -138,6 +140,14 @@ MCP Server for the Fillout.io API, enabling form management, response handling, 
 ## Setup
 
 ### Usage with Claude Desktop
+
+#### Installing via Smithery
+
+To install Fillout.io MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@danielma-tic/server-fillout):
+
+```bash
+npx -y @smithery/cli install @danielma-tic/server-fillout --client claude
+```
 
 #### Docker Configuration
 ```json

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - filloutApiKey
+    properties:
+      filloutApiKey:
+        type: string
+        description: The API key for accessing Fillout.io services.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({command:'node',args:['dist/index.js'],env:{FILLOUT_API_KEY:config.filloutApiKey}})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over SSE so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@danielma-tic/server-fillout?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂